### PR TITLE
Add PM2.5, dust, and odor sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ https://cocoroplusapp.jp.sharp/air
 - [ ] Air Cleaner
     - [x] Temperature Sensor
     - [x] Humidity Sensor
-    - [ ] Air Quality Sensor
+    - [x] PM2.5 Sensor
+    - [x] Dust Sensor
+    - [x] Odor Sensor
     - [ ] Filter Remaining Sensor
     - [ ] Power
     - [ ] Mode

--- a/custom_components/cocoro_air/__init__.py
+++ b/custom_components/cocoro_air/__init__.py
@@ -150,42 +150,73 @@ class CocoroAir:
             _LOGGER.error(f"Error querying devices: {e}")
             raise
 
+    def _fetch_opc(self, device_id, opc):
+        """Fetch a single opc block (k1, k2, etc.) from the sensor API."""
+        url = 'https://cocoroplusapp.jp.sharp/v1/cocoro-air/sensors-conceal/air-cleaner'
+        params = {
+            'device_id': device_id,
+            'event_key': 'echonet_property',
+            'opc': opc,
+        }
+
+        res = self.opener.get(url, params=params)
+
+        if res.status_code == 401:
+            _LOGGER.info('Session expired, re-login')
+            self.login()
+            res = self.opener.get(url, params=params)
+
+        data = res.json().get('sensors_aircleaner_021', {}).get('body', {}).get('data', [{}])[0]
+        return data.get(opc)
+
     def get_sensor_data(self, device_id):
         if not device_id:
             _LOGGER.error("Device ID not provided")
             return None
 
-        res = self.opener.get(f'https://cocoroplusapp.jp.sharp/v1/cocoro-air/sensors-conceal/air-cleaner', params={
-            'device_id': device_id,
-            'event_key': 'echonet_property',
-            'opc': 'k1',
-        })
-
-        if res.status_code == 401:
-            _LOGGER.info('Login again')
-            self.login()
-            res = self.opener.get(f'https://cocoroplusapp.jp.sharp/v1/cocoro-air/sensors-conceal/air-cleaner', params={
-                'device_id': device_id,
-                'event_key': 'echonet_property',
-                'opc': 'k1',
-            })
-
-        _LOGGER.debug(f'cocoro-air response: {res.text}')
-
         try:
-            k1_data = res.json()['sensors_aircleaner_021']['body']['data'][0]['k1']
-        except (KeyError, ValueError, IndexError) as e:
-            _LOGGER.error(f'Failed to get sensor data: {e}, response: {res.text}')
+            k1 = self._fetch_opc(device_id, 'k1')
+        except Exception as e:
+            _LOGGER.error(f'Failed to fetch k1: {e}')
             return None
 
+        if not k1:
+            _LOGGER.error('k1 data is empty')
+            return None
+
+        _LOGGER.debug(f'k1 raw: {k1}')
+
         try:
-            temperature = int(k1_data['s1'], 16)
-            humidity = int(k1_data['s2'], 16)
+            temperature = int(k1['s1'], 16)
+            humidity = int(k1['s2'], 16)
         except (KeyError, ValueError) as e:
-            _LOGGER.error(f'Failed to parse sensor values: {e}, data: {k1_data}')
+            _LOGGER.error(f'Failed to parse sensor values: {e}, data: {k1}')
             return None
 
-        return {
+        result = {
             'temperature': temperature,
             'humidity': humidity,
         }
+
+        # PM2.5 from k1.s8 (µg/m³)
+        try:
+            if 's8' in k1:
+                result['pm25'] = int(k1['s8'], 16)
+        except (ValueError, TypeError) as e:
+            _LOGGER.warning(f'Failed to parse PM2.5 from k1.s8: {e}')
+
+        # k2 contains dust and odor levels (only available when device is actively running)
+        try:
+            k2 = self._fetch_opc(device_id, 'k2')
+            if k2:
+                _LOGGER.debug(f'k2 raw: {k2}')
+                if 's16' in k2:
+                    result['odor'] = int(k2['s16'], 16)
+                if 's17' in k2:
+                    result['dust'] = int(k2['s17'], 16)
+            else:
+                _LOGGER.debug('k2 empty (device may be in standby)')
+        except Exception as e:
+            _LOGGER.debug(f'k2 fetch failed: {e}')
+
+        return result

--- a/custom_components/cocoro_air/sensor.py
+++ b/custom_components/cocoro_air/sensor.py
@@ -9,7 +9,10 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import UnitOfTemperature
+from homeassistant.const import (
+    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    UnitOfTemperature,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -50,6 +53,9 @@ async def async_setup_entry(
 
         entities.append(CocoroAirTemperatureSensor(coordinator))
         entities.append(CocoroAirHumiditySensor(coordinator))
+        entities.append(CocoroAirPM25Sensor(coordinator))
+        entities.append(CocoroAirDustSensor(coordinator))
+        entities.append(CocoroAirOdorSensor(coordinator))
 
     async_add_entities(entities)
 
@@ -84,13 +90,15 @@ class MyCoordinator(DataUpdateCoordinator):
 class CocoroAirSensorBase(CoordinatorEntity, SensorEntity):
     """Base class for Cocoro Air sensor."""
 
+    _data_key: str = ""
+
     def __init__(self, coordinator: DataUpdateCoordinator, name: str,
-                 device_class: SensorDeviceClass, state_class: str, unit_of_measurement: str):
+                 device_class: SensorDeviceClass | None, state_class: str,
+                 unit_of_measurement: str | None):
         """Initialize the sensor."""
         super().__init__(coordinator)
         self._attr_name = name
-        # Unique ID must include device_id to distinguish between same sensors on different devices
-        self._attr_unique_id = f"{DOMAIN}_{coordinator.device_id}_{name.lower()}"
+        self._attr_unique_id = f"{DOMAIN}_{coordinator.device_id}_{name.lower().replace(' ', '_')}"
         self._attr_device_class = device_class
         self._attr_state_class = state_class
         self._attr_native_unit_of_measurement = unit_of_measurement
@@ -99,7 +107,7 @@ class CocoroAirSensorBase(CoordinatorEntity, SensorEntity):
     def native_value(self):
         """Return the state of the sensor."""
         if self.coordinator.data:
-            return self.coordinator.data.get(self._attr_name.lower())
+            return self.coordinator.data.get(self._data_key)
         return None
 
     @property
@@ -114,30 +122,70 @@ class CocoroAirSensorBase(CoordinatorEntity, SensorEntity):
 
 
 class CocoroAirTemperatureSensor(CocoroAirSensorBase):
-    """Cocoro Air temperature sensor."""
+    _data_key = "temperature"
 
     def __init__(self, coordinator: DataUpdateCoordinator):
-        """Initialize the sensor."""
         super().__init__(
             coordinator,
             "Temperature",
             SensorDeviceClass.TEMPERATURE,
             SensorStateClass.MEASUREMENT,
-            UnitOfTemperature.CELSIUS
+            UnitOfTemperature.CELSIUS,
         )
         self._attr_icon = "mdi:thermometer"
 
 
 class CocoroAirHumiditySensor(CocoroAirSensorBase):
-    """Cocoro Air humidity sensor."""
+    _data_key = "humidity"
 
     def __init__(self, coordinator: DataUpdateCoordinator):
-        """Initialize the sensor."""
         super().__init__(
             coordinator,
             "Humidity",
             SensorDeviceClass.HUMIDITY,
             SensorStateClass.MEASUREMENT,
-            "%"
+            "%",
         )
         self._attr_icon = "mdi:water-percent"
+
+
+class CocoroAirPM25Sensor(CocoroAirSensorBase):
+    _data_key = "pm25"
+
+    def __init__(self, coordinator: DataUpdateCoordinator):
+        super().__init__(
+            coordinator,
+            "PM2.5",
+            SensorDeviceClass.PM25,
+            SensorStateClass.MEASUREMENT,
+            CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        )
+        self._attr_icon = "mdi:blur"
+
+
+class CocoroAirDustSensor(CocoroAirSensorBase):
+    _data_key = "dust"
+
+    def __init__(self, coordinator: DataUpdateCoordinator):
+        super().__init__(
+            coordinator,
+            "Dust",
+            None,
+            SensorStateClass.MEASUREMENT,
+            None,
+        )
+        self._attr_icon = "mdi:blur"
+
+
+class CocoroAirOdorSensor(CocoroAirSensorBase):
+    _data_key = "odor"
+
+    def __init__(self, coordinator: DataUpdateCoordinator):
+        super().__init__(
+            coordinator,
+            "Odor",
+            None,
+            SensorStateClass.MEASUREMENT,
+            None,
+        )
+        self._attr_icon = "mdi:scent"


### PR DESCRIPTION
## Summary

- Add three new air quality sensors: **PM2.5** (µg/m³), **Dust** level, and **Odor** level
- PM2.5 is parsed from `k1.s8`; dust and odor are parsed from `k2.s17` / `k2.s16` respectively
- `k2` data is only available when the device is actively running — sensors gracefully show as unavailable in standby mode
- Extract `_fetch_opc()` helper to reduce code duplication in API calls
- Add `_data_key` class variable to `CocoroAirSensorBase` for explicit data key mapping (previously relied on `name.lower()` which is fragile for names like "PM2.5")

## Field mapping notes

The k1/k2 field mapping is based on cross-referencing with [spect88/cocoro](https://github.com/spect88/cocoro)'s F1/F2 binary status byte offsets:
- PM2.5: F1 byte 28 → `k1.s8`
- Odor: F2 byte 15 → `k2.s16` (0/33/66/100 scale, 0 = clean)
- Dust: F2 byte 16 → `k2.s17` (0/25/50/75/100 scale, 0 = clean)

## Test plan

- [x] Tested on Sharp KI-LP100 air purifier
- [x] Verified temperature (26°C) and humidity (50%) unchanged
- [x] PM2.5 reads 29 µg/m³ (consistent with "low" level on COCORO AIR app)
- [x] Dust and odor read 0 when air is clean
- [x] Sensors show unavailable when k2 is empty (device in standby)
- [ ] Could use additional testing on other Sharp air purifier models

🤖 Generated with [Claude Code](https://claude.ai/code)